### PR TITLE
use terms from published post

### DIFF
--- a/lib/wordpress.js
+++ b/lib/wordpress.js
@@ -37,6 +37,7 @@ module.exports = {
         var lastRevision = context.resources.revisions[0];
         if (originalPreprocessor) { context = originalPreprocessor(context); }
         var previewContext = _.extend({}, context.resources.wordpress, lastRevision);
+        previewContext.terms = context.resources.wordpress.terms; // WordPress preview response has blank terms key
         return previewContext;
       }
     };

--- a/lib/wordpress.js
+++ b/lib/wordpress.js
@@ -37,7 +37,12 @@ module.exports = {
         var lastRevision = context.resources.revisions[0];
         if (originalPreprocessor) { context = originalPreprocessor(context); }
         var previewContext = _.extend({}, context.resources.wordpress, lastRevision);
-        previewContext.terms = context.resources.wordpress.terms; // WordPress preview response has blank terms key
+
+        // WP-API v1.2.4 wrongly returns a blank terms key for revisions, but WP-API 2.x.x does not
+        if (typeof lastRevision.terms == 'object' && lastRevision.terms.length == 0) {
+          previewContext.terms = context.resources.wordpress.terms; // use original terms for preview
+        }
+
         return previewContext;
       }
     };


### PR DESCRIPTION
Since the WordPress preview (revisions) endpoint doesn't include terms, but instead contains an empty terms array, the terms are overwritten when the objects are merged. So that those don't disappear from previews, I'm reassigning them here. Thoughts @pushred?